### PR TITLE
Add support for asymmetric quantization

### DIFF
--- a/py/torch_migraphx/dynamo/quantization/migraphx_quantizer.py
+++ b/py/torch_migraphx/dynamo/quantization/migraphx_quantizer.py
@@ -33,7 +33,7 @@
 import torch
 from torch.ao.quantization.quantizer import QuantizationSpec, Quantizer
 
-from .migraphx_quantizer_utils import OP_ANNOTATORS, OP_DEFAULT_CONFIGS
+from .migraphx_quantizer_utils import OP_ANNOTATORS, OP_DEFAULT_CONFIGS, annotate_const_nodes
 
 
 # TODO: Add way to override default configs
@@ -62,6 +62,7 @@ class MGXQuantizer(Quantizer):
             OP_ANNOTATORS[op](n, op_config)
 
     def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+        annotate_const_nodes(model)
         self._annotate_static_quantization(model)
         return model
 

--- a/py/torch_migraphx/dynamo/quantization/migraphx_quantizer.py
+++ b/py/torch_migraphx/dynamo/quantization/migraphx_quantizer.py
@@ -40,10 +40,14 @@ from .migraphx_quantizer_utils import OP_ANNOTATORS, OP_DEFAULT_CONFIGS
 # TODO: Support QAT
 class MGXQuantizer(Quantizer):
 
-    def __init__(self, per_ch_weights=True, is_qat=False):
+    def __init__(self,
+                 per_ch_weights=True,
+                 asymmetric_activations=False,
+                 is_qat=False):
         super().__init__()
         self.per_ch_weights = per_ch_weights
         self.is_qat = is_qat
+        self.asymmetric_activations = asymmetric_activations
         self.default_configs = OP_DEFAULT_CONFIGS
 
     def _annotate_static_quantization(self, model: torch.fx.GraphModule):
@@ -53,6 +57,7 @@ class MGXQuantizer(Quantizer):
                 continue
 
             op_config = self.default_configs[op](self.per_ch_weights,
+                                                 self.asymmetric_activations,
                                                  self.is_qat)
             OP_ANNOTATORS[op](n, op_config)
 

--- a/py/torch_migraphx/fx/converters/quant_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/quant_ops_converters.py
@@ -102,11 +102,6 @@ def aten_ops_quantize_per_tensor(mgx_module, node, args, kwargs):
     inp, scale, zp, q_min, q_max, dtype = args
     assert dtype == torch.int8, "MGXQuantizer should always use signed int8"
 
-    if zp != 0:
-        _LOGGER.warning(
-            "Encoutered non-symmetric quantization."
-            "MGXQuantizer should be used when calling the prepare_pt2e API.")
-
     return add_quantize_linear(mgx_module, inp.instr_ref, scale, zp)
 
 

--- a/tests/dynamo/quantization/test_quantized_models_dynamo.py
+++ b/tests/dynamo/quantization/test_quantized_models_dynamo.py
@@ -59,7 +59,6 @@ def test_quant_vision_model(model_name, model_weights, rtol, atol, asymm,
     "model_class, tokenizer_class, model_name, rtol, atol",
     [
         ('GPT2Model', 'GPT2Tokenizer', 'distilgpt2', 1e-1, 1e-1),
-        # ('GPT2Model', 'GPT2Tokenizer', 'gpt2-large'),
     ])
 @pytest.mark.parametrize("asymm", [False, True])
 def test_quant_LLM(model_class, tokenizer_class, model_name, rtol, atol, asymm,
@@ -84,7 +83,6 @@ def test_quant_LLM(model_class, tokenizer_class, model_name, rtol, atol, asymm,
     q_m = move_q_gm_to_device(q_m)
 
     mgx_mod = torch.compile(q_m, backend='migraphx').cuda()
-    # mgx_out = mgx_mod(inputs[0].cuda())
 
     torch_fp32_out, torch_q_out, mgx_out = compute_quantized_outputs(
         torch_fp32_mod, torch_q_mod, mgx_mod, inputs)


### PR DESCRIPTION
This set of changes enable running asymmetrically quantized models using MIGraphX. Test case logic for quantized models has also been updated to allow verifying full models.

Changes:
1. Update MGXQuantizer to support asymmetric quantization specs
2. Update annotators for ambiguous gemm ops (eg. matmul, addmm) to look for weight argument
a. Before annotating do a pass to determine which nodes are constants
b. Use weight quantization spec for constant node inputs rather than assuming order of activation and weight nodes
3. Update perf script to accept `--asymmetric` flag 
4. Test cases
a. Add cases for asymmetric config
b. Update verify logic for quantized modules to only check for accuracy on elements where the fake quantized result is within tolerance
c. Remove gpt2-large from test cases. LLMs should be tested using smaller subgraphs as trying to test with large models causes failures on devices that do not have enough memory.

This includes all the required changes to support asymmetric quantization in the torch.compile workflow. Will create a separate PR for adding support in the FX workflow.